### PR TITLE
[MM-23159] Highlight Group Names

### DIFF
--- a/src/selectors/entities/groups.ts
+++ b/src/selectors/entities/groups.ts
@@ -6,6 +6,7 @@ import {Group} from 'types/groups';
 import {filterGroupsMatchingTerm} from 'utils/group_utils';
 import {getChannel} from 'selectors/entities/channels';
 import {getTeam} from 'selectors/entities/teams';
+import {UserMentionKey} from 'selectors/entities/users';
 
 const emptyList: any[] = [];
 const emptySyncables = {
@@ -145,6 +146,15 @@ export const getAllAssociatedGroupsForReference = reselect.createSelector(
     getAllGroups,
     (allGroups) => {
         return Object.entries(allGroups).filter((entry) => entry[1].allow_reference).map((entry) => entry[1]);
+    }
+);
+
+export const getCurrentUserGroupMentionKeys = reselect.createSelector(
+    getAllAssociatedGroupsForReference,
+    (groups: Array<Group>) => {
+        const keys: UserMentionKey[] = [];
+        groups.forEach((group) => keys.push({key: `@${group.name}`}));
+        return keys;
     }
 );
 

--- a/src/selectors/entities/search.test.js
+++ b/src/selectors/entities/search.test.js
@@ -26,4 +26,39 @@ describe('Selectors.Search', () => {
     it('should return current search for current team', () => {
         assert.deepEqual(Selectors.getCurrentSearchForCurrentTeam(testState), team1CurrentSearch);
     });
+
+    it('groups', () => {
+        const userId = '1234';
+        const notifyProps = {
+            first_name: 'true',
+        };
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: userId,
+                    profiles: {
+                        [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last', notify_props: notifyProps},
+                    },
+                },
+                groups: {
+                    groups: {
+                        test1: {
+                            name: 'I-AM-THE-BEST!',
+                            allow_reference: true,
+                        },
+                        test2: {
+                            name: 'Do-you-love-me?',
+                            allow_reference: true,
+                        },
+                        test3: {
+                            name: 'Maybe?-A-little-bit-I-guess....',
+                            allow_reference: false,
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.deepEqual(Selectors.getAllUserMentionKeys(state), [{key: 'First', caseSensitive: true}, {key: '@user'}, {key: '@I-AM-THE-BEST!'}, {key: '@Do-you-love-me?'}]);
+    });
 });

--- a/src/selectors/entities/search.ts
+++ b/src/selectors/entities/search.ts
@@ -4,6 +4,8 @@
 import * as reselect from 'reselect';
 
 import {getCurrentTeamId} from 'selectors/entities/teams';
+import {getCurrentUserMentionKeys} from 'selectors/entities/users';
+import {getCurrentUserGroupMentionKeys} from 'selectors/entities/groups';
 
 import * as types from 'types';
 
@@ -12,5 +14,13 @@ export const getCurrentSearchForCurrentTeam = reselect.createSelector(
     getCurrentTeamId,
     (current, teamId) => {
         return current[teamId];
+    }
+);
+
+export const getAllUserMentionKeys = reselect.createSelector(
+    getCurrentUserMentionKeys,
+    getCurrentUserGroupMentionKeys,
+    (userMentionKeys, groupMentionKeys) => {
+        return userMentionKeys.concat(groupMentionKeys);
     }
 );

--- a/src/selectors/entities/users.ts
+++ b/src/selectors/entities/users.ts
@@ -119,36 +119,38 @@ export type UserMentionKey= {
     caseSensitive?: boolean;
 }
 
-export const getCurrentUserMentionKeys: (a: GlobalState) => Array<UserMentionKey> = createSelector(getCurrentUser, (user: UserProfile) => {
-    let keys: UserMentionKey[] = [];
+export const getCurrentUserMentionKeys: (a: GlobalState) => Array<UserMentionKey> = createSelector(
+    getCurrentUser,
+    (user: UserProfile) => {
+        let keys: UserMentionKey[] = [];
 
-    if (!user || !user.notify_props) {
+        if (!user || !user.notify_props) {
+            return keys;
+        }
+
+        if (user.notify_props.mention_keys) {
+            keys = keys.concat(user.notify_props.mention_keys.split(',').map((key) => {
+                return {key};
+            }));
+        }
+
+        if (user.notify_props.first_name === 'true' && user.first_name) {
+            keys.push({key: user.first_name, caseSensitive: true});
+        }
+
+        if (user.notify_props.channel === 'true') {
+            keys.push({key: '@channel'});
+            keys.push({key: '@all'});
+            keys.push({key: '@here'});
+        }
+
+        const usernameKey = '@' + user.username;
+        if (keys.findIndex((key) => key.key === usernameKey) === -1) {
+            keys.push({key: usernameKey});
+        }
+
         return keys;
     }
-
-    if (user.notify_props.mention_keys) {
-        keys = keys.concat(user.notify_props.mention_keys.split(',').map((key) => {
-            return {key};
-        }));
-    }
-
-    if (user.notify_props.first_name === 'true' && user.first_name) {
-        keys.push({key: user.first_name, caseSensitive: true});
-    }
-
-    if (user.notify_props.channel === 'true') {
-        keys.push({key: '@channel'});
-        keys.push({key: '@all'});
-        keys.push({key: '@here'});
-    }
-
-    const usernameKey = '@' + user.username;
-    if (keys.findIndex((key) => key.key === usernameKey) === -1) {
-        keys.push({key: usernameKey});
-    }
-
-    return keys;
-}
 );
 
 export const getProfileSetInCurrentChannel: (a: GlobalState) => Array<$ID<UserProfile>> = createSelector(


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
This change adds groups that are allowed to be referenced to the keys array of mention keys so that it is highlighted like we do for `@here` and `@channel` and so on. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23159

#### Screenshot
![image](https://user-images.githubusercontent.com/17804942/76542821-f006cb00-645b-11ea-976e-cd369704268e.png)